### PR TITLE
Bump version to 0.5.28 and add Qorus library and Qog interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/ts-toolkit",
-  "version": "0.5.27",
+  "version": "0.5.28",
   "description": "Utility library to interact with Qorus Integration Engine & Qore Language",
   "keywords": [
     "qoretechnologies",

--- a/src/types/api/library.ts
+++ b/src/types/api/library.ts
@@ -1,0 +1,50 @@
+export interface QorusLibrary {
+  functions: QorusLibraryFunctions;
+  classes: QorusLibraryClasses;
+  constants: QorusLibraryConstants;
+  pipelines: QorusLibraryPipelines;
+  fsm: QorusLibraryQogs;
+  mapper: QorusLibraryMappers;
+}
+
+export interface QorusLibraryItem {
+  name: string;
+  id: number;
+  version?: string;
+}
+
+export interface QorusLibraryFunctions {
+  [functionName: string]: QorusLibraryFunction;
+}
+
+export interface QorusLibraryClasses {
+  [className: string]: QorusLibraryClass;
+}
+
+export interface QorusLibraryConstants {
+  [constantName: string]: QorusLibraryConstant;
+}
+
+export interface QorusLibraryPipelines {
+  [pipelineName: string]: QorusLibraryPipeline;
+}
+
+export interface QorusLibraryMappers {
+  [mapperName: string]: QorusLibraryMapper;
+}
+
+export interface QorusLibraryQogs {
+  [qogName: string]: QorusLibraryQog;
+}
+
+export interface QorusLibraryClass extends QorusLibraryItem {}
+
+export interface QorusLibraryConstant extends QorusLibraryItem {}
+
+export interface QorusLibraryPipeline extends QorusLibraryItem {}
+
+export interface QorusLibraryMapper extends QorusLibraryItem {}
+
+export interface QorusLibraryQog extends QorusLibraryItem {}
+
+export interface QorusLibraryFunction extends QorusLibraryItem {}

--- a/src/types/api/qogs.ts
+++ b/src/types/api/qogs.ts
@@ -49,7 +49,7 @@ export interface QorusQogState {
   transitions: QorusQogTransition[];
   is_event_trigger?: boolean;
   type?: string;
-  condition?: string | Object;
+  condition?: string | unknown;
   language?: QorusProgrammingLanguage;
   'block-config'?: Record<string, any>;
 }

--- a/src/types/api/qogs.ts
+++ b/src/types/api/qogs.ts
@@ -1,0 +1,62 @@
+import { QorusConfigItem, QorusInterfaceGroups, QorusInterfaceTags, QorusProgrammingLanguage } from '../qorus';
+import { QorusLibrary } from './library';
+
+export interface QorusQog {
+  fsmid: number;
+  name: string;
+  display_name: string;
+  description?: string;
+  short_desc: string;
+  type: 'none' | 'event' | 'on-demand' | 'scheduled';
+  created: string;
+  modified: string;
+  schedule?: {
+    minute: string;
+    hour: string;
+    day: string;
+    month: string;
+    wday: string;
+  };
+  next?: string;
+  config: Record<string, QorusConfigItem>;
+  lib: QorusLibrary;
+  states: Record<string, QorusQogState>;
+  groups: QorusInterfaceGroups;
+  last_error?: string;
+  enabled?: boolean;
+  active?: boolean;
+  supports_active?: boolean;
+  on_demand?: boolean;
+  running?: boolean;
+  tags?: QorusInterfaceTags;
+  last_jobstatus?: string;
+}
+
+export interface QorusQogState {
+  name: string;
+  action: {
+    type: string;
+    value: any;
+  };
+  desc: string;
+  id: string;
+  initial: boolean;
+  execution_order: number;
+  position: {
+    x: number;
+    y: number;
+  };
+  transitions: QorusQogTransition[];
+  is_event_trigger?: boolean;
+  type?: string;
+  condition?: string | Object;
+  language?: QorusProgrammingLanguage;
+  'block-config'?: Record<string, any>;
+}
+
+export interface QorusQogTransition {
+  state: string;
+  branch?: 'true' | 'false';
+  language: QorusProgrammingLanguage;
+  condition: string | { class: string; connector: string };
+}

--- a/src/types/qorus.ts
+++ b/src/types/qorus.ts
@@ -38,3 +38,30 @@ export type TQorusType =
   | TQorusAnyCompatibleUIType
   | TQorusBooleanCompatibleUIType
   | TQorusSpecialUIType;
+
+export type QorusProgrammingLanguage = 'qore' | 'python' | 'java';
+
+export interface QorusConfigItem {
+  type: TQorusType;
+  desc: string;
+  strictly_local?: boolean;
+  config_group?: string;
+  sensitive?: boolean;
+  prefix?: string;
+  value: any;
+  level?: string;
+  is_set?: boolean;
+  is_templated_string?: boolean;
+}
+
+export interface QorusInterfaceGroups {
+  [groupName: string]: {
+    name: string;
+    enabled?: boolean;
+    size: number;
+  };
+}
+
+export interface QorusInterfaceTags {
+  [tagName: string]: any;
+}


### PR DESCRIPTION
Update the version number and introduce new interfaces for the Qorus library and Qog, enhancing the integration capabilities. Refactor the QorusQogState interface to improve type safety.