### PR TITLE
Bump version to 0.5.30 and add QorusAlert and QorusService types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,11 +32,6 @@
     "@typescript-eslint/no-unsafe-return": "warn",
     "@typescript-eslint/no-unsafe-call": "warn",
     "@typescript-eslint/naming-convention": "warn",
-    "@typescript-eslint/no-empty-interface": [
-      "error",
-      {
-        "allowSingleExtends": true
-      }
-    ]
+    "@typescript-eslint/no-empty-interface": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qoretechnologies/ts-toolkit",
-  "version": "0.5.29",
+  "version": "0.5.30",
   "description": "Utility library to interact with Qorus Integration Engine & Qore Language",
   "keywords": [
     "qoretechnologies",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,10 @@ export { TContext } from './QorusDataProvider';
 export { IDefaultHeaders } from './QorusRequest';
 export { IApiPaths, IAuthenticatorApiPaths, IDataProviderApiPaths, IJobsApiPaths, TVersion } from './utils/apiPaths';
 
+export * from './types/api/alerts';
 export * from './types/api/library';
 export * from './types/api/qogs';
+export * from './types/api/services';
 export * from './types/api/system';
 export * from './types/expressions';
 export * from './types/forms';

--- a/src/types/api/alerts.ts
+++ b/src/types/api/alerts.ts
@@ -1,0 +1,26 @@
+export type QorusAlertType = 'ONGOING' | 'TRANSIENT';
+export interface QorusAlert {
+  alert: string;
+  alertid: number;
+  alerttype: QorusAlertType;
+  auditid?: number;
+  config?: Record<string, any>;
+  conntype?: string;
+  connectionid?: number;
+  description?: string;
+  first_raised?: string;
+  id: string | number;
+  instance: string;
+  local: boolean;
+  name: string;
+  object: string;
+  reason: string;
+  servicetype?: string;
+  source: string;
+  stateless?: boolean;
+  type: string;
+  url?: string;
+  version?: string;
+  when: string;
+  who: string;
+}

--- a/src/types/api/library.ts
+++ b/src/types/api/library.ts
@@ -1,10 +1,10 @@
 export interface QorusLibrary {
-  functions: QorusLibraryFunctions;
-  classes: QorusLibraryClasses;
-  constants: QorusLibraryConstants;
-  pipelines: QorusLibraryPipelines;
-  fsm: QorusLibraryQogs;
-  mapper: QorusLibraryMappers;
+  functions?: QorusLibraryFunction[];
+  classes?: QorusLibraryClass[];
+  constants?: QorusLibraryConstant[];
+  pipelines?: QorusLibraryPipeline[];
+  fsm?: QorusLibraryQog[];
+  mapper?: QorusLibraryMapper[];
 }
 
 export interface QorusLibraryItem {
@@ -13,38 +13,23 @@ export interface QorusLibraryItem {
   version?: string;
 }
 
-export interface QorusLibraryFunctions {
-  [functionName: string]: QorusLibraryFunction;
-}
-
-export interface QorusLibraryClasses {
-  [className: string]: QorusLibraryClass;
-}
-
-export interface QorusLibraryConstants {
-  [constantName: string]: QorusLibraryConstant;
-}
-
-export interface QorusLibraryPipelines {
-  [pipelineName: string]: QorusLibraryPipeline;
-}
-
-export interface QorusLibraryMappers {
-  [mapperName: string]: QorusLibraryMapper;
-}
-
-export interface QorusLibraryQogs {
-  [qogName: string]: QorusLibraryQog;
-}
-
 export interface QorusLibraryClass extends QorusLibraryItem {}
 
 export interface QorusLibraryConstant extends QorusLibraryItem {}
 
 export interface QorusLibraryPipeline extends QorusLibraryItem {}
 
-export interface QorusLibraryMapper extends QorusLibraryItem {}
+export interface QorusLibraryMapper extends Pick<QorusLibraryItem, 'name' | 'version'> {
+  mapperid: number;
+  type: 'Mapper';
+}
 
 export interface QorusLibraryQog extends QorusLibraryItem {}
 
 export interface QorusLibraryFunction extends QorusLibraryItem {}
+
+export interface QorusLibraryValueMap extends QorusLibraryItem {
+  throws_exception: boolean;
+  valuetype: string;
+  mapsize: number;
+}

--- a/src/types/api/services.ts
+++ b/src/types/api/services.ts
@@ -1,0 +1,82 @@
+import { QorusAlert } from './alerts';
+import { QorusLibrary } from './library';
+
+export interface QorusService {
+  type: 'user' | 'system'; // the type of the service
+  name: string; // the service name
+  version: string; // the service version
+  patch?: string; // the service patch string (if any)
+  display_name?: string; // the display name
+  short_desc?: string; // the short description in plain text
+  desc?: string; // the service description
+  author?: string; // the author of the service (if any)
+  serviceid: number; // the service ID
+  remote: boolean; // if the service is remote or not
+  stateless: boolean; // True if the service is stateless
+  parse_options?: any[]; // a list of symbolic parse options for the service program container (if any)
+  status: string; // the status of the service; one of: "loaded", "running", "unloaded"
+  processes?: QorusProcessInfo[]; // a list of service processes running for this service
+  config?: Record<string, ConfigItemInfo>; // a hash of configuration item info keyed by config item name
+  global_config?: Record<string, GlobalConfigItemInfo>; // a hash of global configuration item info keyed by config item name
+  log?: string; // the complete path to the service log file
+  threads?: number; // the number of active threads in the service
+  autostart: boolean; // boolean value indicating if the service should be autostarted or not
+  manual_autostart: boolean; // boolean flag set if the autostart value has been changed manually
+  loaded?: Date; // date/time the service was loaded
+  methods: MethodInfo[]; // a list of hashes for each service method
+  resources?: Record<string, ServiceResourceDetailInfo>; // a hash of service resources (if any), keys are resource names
+  resource_files?: ServiceFileResourceInfo[]; // a list of hashes giving service resource file information (if any)
+  options?: OptionValueInfo[]; // a hash of options set on the service
+  service_modules?: string[]; // a list of associated modules
+  groups?: GroupInfo[]; // a list of interface groups that the service belongs to
+  alerts?: QorusAlert[]; // a list of alerts raised against the workflow
+  waiting_threads?: number; // how many threads are currently waiting on the service (running services only)
+  active_calls?: number; // currently active calls on the service (running services only)
+  lib?: QorusLibrary; // information about any referenced Qorus objects
+  log_url?: string; // the log URL (if any)
+  enabled: boolean; // a boolean flag indicating if the service is enabled or not
+  connections?: InterfaceConnectionInfo[]; // a list of connection objects that this service depends on
+  tags?: Record<string, any>; // any tags for the service
+}
+
+interface QorusProcessInfo {
+  // Define fields for QorusProcessInfo here
+}
+
+interface ConfigItemInfo {
+  // Define fields for ConfigItemInfo here
+}
+
+interface GlobalConfigItemInfo {
+  // Define fields for GlobalConfigItemInfo here
+}
+
+interface MethodInfo {
+  name: string;
+  desc?: string;
+}
+
+interface ServiceResourceDetailInfo {
+  type: string;
+  desc?: string;
+  info?: Record<string, any>;
+}
+
+interface ServiceFileResourceInfo {
+  type: string;
+  name: string;
+}
+
+interface OptionValueInfo {
+  name: string;
+  desc?: string;
+  value: any;
+}
+
+interface GroupInfo {
+  // Define fields for GroupInfo here
+}
+
+interface InterfaceConnectionInfo {
+  // Define fields for InterfaceConnectionInfo here
+}


### PR DESCRIPTION
Introduce new types and interfaces for QorusAlert and QorusService, while updating the version number. Adjust ESLint configuration to disable the no-empty-interface rule.